### PR TITLE
Ensure integration test checks Genesis verse content

### DIFF
--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -52,8 +52,10 @@ fn test_bible_creation_with_real_data() {
     if let Some(verse) = bible.get_verse(BibleBook::Genesis, 1, 1) {
         // We can't access private fields, but we can test the Display trait
         let verse_str = format!("{}", verse);
-        assert!(!verse_str.is_empty());
-        assert!(verse_str.contains("1:"));
+        assert_eq!(
+            verse_str,
+            "1: In the beginning God created the heaven and the earth."
+        );
     }
 
     // Test that we can get a book


### PR DESCRIPTION
## Summary
- Strengthen `test_bible_creation_with_real_data` by asserting the exact text of Genesis 1:1

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_b_689f87673bc4832b9fceae2f1e3e0636