### PR TITLE
Use KJV fixture in basic usage example

### DIFF
--- a/examples/basic_usage.rs
+++ b/examples/basic_usage.rs
@@ -1,7 +1,7 @@
 use rust_bible_struct::{Bible, BibleBook};
 
 fn main() {
-    let file_path = "tests/fixtures/bbe.json";
+    let file_path = "tests/fixtures/en_kjv.json";
 
     let bible: Bible = Bible::new_from_json(file_path);
 


### PR DESCRIPTION
## Summary
- point the basic usage example to the `en_kjv.json` fixture

## Testing
- `cargo run --example basic_usage`


------
https://chatgpt.com/codex/tasks/task_b_689f8741891c832bbc0df9239bec2332