### PR TITLE
Replace bbe.json references with en_kjv.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,29 +53,29 @@ cargo run --example basic_usage
 rust_bible_struct/
 ├── src/                    # Source code
 ├── tests/                  # Integration tests
-│   ├── fixtures/          # Test data files (recommended location for bbe.json)
+│   ├── fixtures/          # Test data files (recommended location for en_kjv.json)
 │   ├── common.rs          # Shared test utilities
 │   └── integration_tests.rs # Main test suite
 ├── examples/               # Usage examples
-└── bbe.json               # Bible data file (can be moved to tests/fixtures/)
+└── en_kjv.json            # Bible data file (can be moved to tests/fixtures/)
 ```
 
 ## Test Data Organization
 
 The library includes integration tests that require Bible data. For best practices:
 
-- **Recommended**: Place `bbe.json` in `tests/fixtures/` directory
-- **Alternative**: Place `bbe.json` directly in `tests/` directory
-- **Fallback**: Place `bbe.json` in project root
+- **Recommended**: Place `en_kjv.json` in `tests/fixtures/` directory
+- **Alternative**: Place `en_kjv.json` directly in `tests/` directory
+- **Fallback**: Place `en_kjv.json` in project root
 
 Use the provided scripts to automatically move your data file:
-- **Windows**: `.\move_bbe_json.ps1`
-- **Linux/macOS**: `./move_bbe_json.sh`
+- **Windows**: `.\move_en_kjv_json.ps1`
+- **Linux/macOS**: `./move_en_kjv_json.sh`
 
 ## Running Tests
 
 ```bash
-# Run all tests (requires bbe.json)
+# Run all tests (requires en_kjv.json)
 cargo test
 
 # Run only unit tests (no external data required)

--- a/examples/basic_usage.rs
+++ b/examples/basic_usage.rs
@@ -1,7 +1,7 @@
 use rust_bible_struct::{Bible, BibleBook};
 
 fn main() {
-    let file_path = "tests/fixtures/bbe.json";
+    let file_path = "tests/fixtures/en_kjv.json";
 
     let bible: Bible = Bible::new_from_json(file_path);
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -30,13 +30,13 @@ fn test_bible_book_enum_import() {
 
 #[test]
 fn test_bible_creation_with_real_data() {
-    // This test requires the bbe.json file to exist
+    // This test requires the en_kjv.json file to exist
     let file_path = match test_utils::get_kjv_json() {
         Some(path) => path,
         None => {
             // Skip the test if the file doesn't exist
-            println!("Skipping test_bible_creation_with_real_data: bbe.json not found");
-            println!("To run this test, place bbe.json in one of these locations:");
+            println!("Skipping test_bible_creation_with_real_data: en_kjv.json not found");
+            println!("To run this test, place en_kjv.json in one of these locations:");
             println!("  1. tests/fixtures/ (recommended)");
             println!("  2. tests/ directory");
             println!("  3. Project root directory");
@@ -44,7 +44,7 @@ fn test_bible_creation_with_real_data() {
         }
     };
 
-    println!("Using bbe.json at: {}", file_path);
+    println!("Using en_kjv.json at: {}", file_path);
 
     let bible = Bible::new_from_json(&file_path);
 


### PR DESCRIPTION
## Summary
- update project docs and scripts to use en_kjv.json
- adjust example and integration test to load en_kjv.json

## Testing
- `cargo fmt`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_b_689f8751bb40832bbdfcad37424a93ca