### PR TITLE
Improve error messages for invalid scripture lookups

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,12 @@ fn main() {
     let bible = Bible::new_from_json("path/to/bible.json");
     
     // Get a specific verse
-    if let Some(verse) = bible.get_verse(BibleBook::Genesis, 1, 1) {
+    if let Ok(verse) = bible.get_verse(BibleBook::Genesis, 1, 1) {
         println!("{}", verse);
     }
-    
+
     // Get all verses from a chapter
-    if let Some(verses) = bible.get_verses(BibleBook::Psalms, 23) {
+    if let Ok(verses) = bible.get_verses(BibleBook::Psalms, 23) {
         for verse in verses {
             println!("{}", verse);
         }

--- a/examples/basic_usage.rs
+++ b/examples/basic_usage.rs
@@ -5,7 +5,8 @@ fn main() {
 
     let bible: Bible = Bible::new_from_json(file_path);
 
-    let verse = bible.get_verse(BibleBook::Genesis, 1, 1).unwrap();
-
-    println!("{}", verse);
+    match bible.get_verse(BibleBook::Genesis, 1, 1) {
+        Ok(verse) => println!("{}", verse),
+        Err(e) => eprintln!("Error: {}", e),
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,4 +8,4 @@ pub mod bible_class;
 
 // Re-export main types for easier access
 pub use bible_books_enum::BibleBook;
-pub use bible_class::{Bible, Book, Chapter, Verse};
+pub use bible_class::{Bible, BibleError, Book, Chapter, Verse};

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -49,7 +49,7 @@ fn test_bible_creation_with_real_data() {
     let bible = Bible::new_from_json(&file_path);
 
     // Test that we can get a verse from Genesis
-    if let Some(verse) = bible.get_verse(BibleBook::Genesis, 1, 1) {
+    if let Ok(verse) = bible.get_verse(BibleBook::Genesis, 1, 1) {
         // We can't access private fields, but we can test the Display trait
         let verse_str = format!("{}", verse);
         assert_eq!(
@@ -59,7 +59,7 @@ fn test_bible_creation_with_real_data() {
     }
 
     // Test that we can get a book
-    if let Some(book) = bible.get_book(BibleBook::Genesis) {
+    if let Ok(book) = bible.get_book(BibleBook::Genesis) {
         assert_eq!(book.abbrev(), "gn");
         assert_eq!(book.title(), "Genesis");
     }


### PR DESCRIPTION
## Summary
- Add `BibleError` with detailed messages for missing books, chapters, or verses
- Return `Result` from lookup methods so callers receive descriptive errors
- Include translation name in `BookNotFound` errors for clearer context
- Update examples, tests, and docs to use the new error-handling API

## Testing
- `cargo fmt`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_b_689f8e4e2f40832babd815508a926914