### PR TITLE
Return Result from new_from_json and remove unsafe parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ Basic usage:
 ```rust
 use rust_bible_struct::{Bible, BibleBook};
 
-fn main() {
-    let bible = Bible::new_from_json("path/to/bible.json");
-    
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let bible = Bible::new_from_json("path/to/bible.json")?;
+
     // Get a specific verse
     if let Ok(verse) = bible.get_verse(BibleBook::Genesis, 1, 1) {
         println!("{}", verse);
@@ -36,6 +36,8 @@ fn main() {
             println!("{}", verse);
         }
     }
+
+    Ok(())
 }
 ```
 

--- a/examples/basic_usage.rs
+++ b/examples/basic_usage.rs
@@ -1,12 +1,14 @@
 use rust_bible_struct::{Bible, BibleBook};
 
-fn main() {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     let file_path = "tests/fixtures/en_kjv.json";
 
-    let bible: Bible = Bible::new_from_json(file_path);
+    let bible = Bible::new_from_json(file_path)?;
 
     match bible.get_verse(BibleBook::Genesis, 1, 1) {
         Ok(verse) => println!("{}", verse),
         Err(e) => eprintln!("Error: {}", e),
     }
+
+    Ok(())
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -46,7 +46,7 @@ fn test_bible_creation_with_real_data() {
 
     println!("Using en_kjv.json at: {}", file_path);
 
-    let bible = Bible::new_from_json(&file_path);
+    let bible = Bible::new_from_json(&file_path).expect("Failed to load Bible JSON");
 
     // Test that we can get a verse from Genesis
     if let Ok(verse) = bible.get_verse(BibleBook::Genesis, 1, 1) {


### PR DESCRIPTION
## Summary
- Make `Bible::new_from_json` return `Result` and switch to safe `simd_json` parsing.
- Update examples, README, and tests to handle fallible JSON loading.

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_b_68a05e177154832bb8f52a543f978deb