### PR TITLE
Implement Error trait for BibleError

### DIFF
--- a/src/bible_class.rs
+++ b/src/bible_class.rs
@@ -78,6 +78,8 @@ impl fmt::Display for BibleError {
     }
 }
 
+impl std::error::Error for BibleError {}
+
 #[derive(Deserialize, Debug)]
 struct BibleFileRoot {
     id: String,


### PR DESCRIPTION
## Summary
- implement `std::error::Error` for `BibleError`

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_b_68a05e297e08832b8f367977e59c8c2d