### PR TITLE
Expose verse text and number accessors

### DIFF
--- a/src/bible_class.rs
+++ b/src/bible_class.rs
@@ -119,6 +119,16 @@ impl Verse {
             verse_number,
         }
     }
+
+    /// Returns the text content of the verse.
+    pub fn text(&self) -> &str {
+        &self.verse_text
+    }
+
+    /// Returns the verse number within its chapter.
+    pub fn number(&self) -> usize {
+        self.verse_number
+    }
 }
 
 impl fmt::Display for Verse {


### PR DESCRIPTION
## Summary
- add public getters for verse text and verse number

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_b_68a18330170c832b96702f204354bc3f