### PR TITLE
Add Clone derivations and tests for Bible structures

### DIFF
--- a/src/bible.rs
+++ b/src/bible.rs
@@ -96,7 +96,7 @@ struct FileDataEntry {
 /// Represents the complete Bible with all books, chapters, and verses.
 ///
 /// The Bible struct provides efficient access to any verse, chapter, or book
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Bible {
     books: Vec<Book>,
     index_by_abbrev: HashMap<String, usize>,
@@ -256,10 +256,10 @@ mod tests {
         Bible {
             books: vec![book],
             index_by_abbrev,
-            id: String::new(),
-            name: String::new(),
-            description: String::new(),
-            language: String::new(),
+            id: "id".to_string(),
+            name: "name".to_string(),
+            description: "desc".to_string(),
+            language: "lang".to_string(),
         }
     }
 
@@ -270,5 +270,22 @@ mod tests {
         assert_eq!(book.title(), "Genesis");
         let verse = bible.get_verse(BibleBook::Genesis, 1, 1).unwrap();
         assert_eq!(verse.number(), 1);
+    }
+
+    #[test]
+    fn test_clone_independence() {
+        let original = create_test_bible();
+        let cloned = original.clone();
+
+        assert_eq!(original.id(), cloned.id());
+        assert_eq!(original.name(), cloned.name());
+        assert_eq!(original.description(), cloned.description());
+        assert_eq!(original.language(), cloned.language());
+        assert_eq!(original.books().len(), cloned.books().len());
+        assert_eq!(original.books()[0].title(), cloned.books()[0].title());
+
+        // Ensure cloned Bible owns its data
+        assert_ne!(original.books().as_ptr(), cloned.books().as_ptr());
+        assert_ne!(original.name().as_ptr(), cloned.name().as_ptr());
     }
 }

--- a/src/book.rs
+++ b/src/book.rs
@@ -5,7 +5,7 @@ use crate::{bible::BibleError, chapter::Chapter, verse::Verse};
 /// Represents a book of the Bible.
 ///
 /// A book contains multiple chapters and has an abbreviation and title.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Book {
     abbrev: String, // keep the JSON key, no assumptions about canon
     title: String,
@@ -135,5 +135,19 @@ mod tests {
         assert_eq!(book.title(), "Genesis");
         assert!(book.get_chapter(1).is_ok());
         assert!(book.get_chapter(0).is_err());
+    }
+
+    #[test]
+    fn test_clone_independence() {
+        let book = Book::new("GN".into(), "Genesis".into(), vec![create_test_chapter()]);
+        let cloned = book.clone();
+
+        assert_eq!(book.abbrev(), cloned.abbrev());
+        assert_eq!(book.title(), cloned.title());
+        assert_eq!(book.chapters().len(), cloned.chapters().len());
+
+        // Ensure cloned book owns its data
+        assert_ne!(book.title().as_ptr(), cloned.title().as_ptr());
+        assert_ne!(book.chapters().as_ptr(), cloned.chapters().as_ptr());
     }
 }

--- a/src/chapter.rs
+++ b/src/chapter.rs
@@ -5,7 +5,7 @@ use crate::verse::Verse;
 /// Represents a chapter from a Bible book.
 ///
 /// A chapter contains multiple verses and has a chapter number.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Chapter {
     verses: Vec<Verse>,
     chapter_number: usize,
@@ -80,5 +80,26 @@ mod tests {
         assert_eq!(chapter.get_verses().len(), 1);
         assert_eq!(chapter.get_verse(1).unwrap().number(), 1);
         assert!(chapter.get_verse(0).is_none());
+    }
+
+    #[test]
+    fn test_clone_independence() {
+        let verses = vec![Verse::new("Clone".into(), 1)];
+        let original = Chapter::new(verses, 1);
+        let cloned = original.clone();
+
+        assert_eq!(original.number(), cloned.number());
+        assert_eq!(original.get_verses().len(), cloned.get_verses().len());
+        assert_eq!(
+            original.get_verses()[0].text(),
+            cloned.get_verses()[0].text()
+        );
+
+        // Ensure the cloned chapter owns its data
+        assert_ne!(original.get_verses().as_ptr(), cloned.get_verses().as_ptr());
+        assert_ne!(
+            original.get_verses()[0].text().as_ptr(),
+            cloned.get_verses()[0].text().as_ptr()
+        );
     }
 }

--- a/src/verse.rs
+++ b/src/verse.rs
@@ -3,7 +3,7 @@ use std::fmt;
 /// Represents a single verse from the Bible.
 ///
 /// A verse contains the text content and its verse number within a chapter.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Verse {
     verse_text: String,
     verse_number: usize,
@@ -50,5 +50,17 @@ mod tests {
         assert_eq!(verse.text(), "Test");
         assert_eq!(verse.number(), 1);
         assert_eq!(format!("{}", verse), "1: Test");
+    }
+
+    #[test]
+    fn test_clone_independence() {
+        let original = Verse::new("Clone me".to_string(), 42);
+        let cloned = original.clone();
+
+        assert_eq!(original.text(), cloned.text());
+        assert_eq!(original.number(), cloned.number());
+
+        // Ensure the cloned verse has its own allocation
+        assert_ne!(original.text().as_ptr(), cloned.text().as_ptr());
     }
 }


### PR DESCRIPTION
## Summary
- Derive `Clone` for `Verse`, `Chapter`, `Book`, and `Bible`
- Add unit tests ensuring clones are equal to originals and own their data

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_b_68a3892e94a0832b819b4b7fa7add74b