### PR TITLE
Add case-insensitive verse search and tests

### DIFF
--- a/src/bible.rs
+++ b/src/bible.rs
@@ -205,6 +205,35 @@ impl Bible {
         self.get_verse(book, chapter_number, verse_number)
     }
 
+    /// Searches all verses for a case-insensitive substring match.
+    ///
+    /// This performs a naive linear scan through every verse in the Bible.
+    /// It converts each verse to lowercase on the fly and therefore has
+    /// `O(n)` complexity over the total number of verses. For large texts or
+    /// repeated searches, consider building an index instead.
+    pub fn search(&self, query: &str) -> Vec<(BibleBook, usize, usize)> {
+        if query.is_empty() {
+            return Vec::new();
+        }
+
+        let needle = query.to_ascii_lowercase();
+        let mut results = Vec::new();
+
+        for book in &self.books {
+            if let Ok(book_enum) = BibleBook::from_str(book.abbrev()) {
+                for (chapter_idx, chapter) in book.chapters().iter().enumerate() {
+                    for verse in chapter.get_verses() {
+                        if verse.text().to_ascii_lowercase().contains(&needle) {
+                            results.push((book_enum, chapter_idx + 1, verse.number()));
+                        }
+                    }
+                }
+            }
+        }
+
+        results
+    }
+
     fn parse_error(&self, part: &str) -> BibleError {
         BibleError::BookNotFound {
             book_abbrev: part.to_ascii_lowercase(),

--- a/tests/search_tests.rs
+++ b/tests/search_tests.rs
@@ -1,0 +1,35 @@
+use rust_bible_struct::{Bible, BibleBook};
+
+mod common;
+use common::test_utils;
+
+#[test]
+fn search_finds_multiple_books() {
+    let file_path = match test_utils::get_kjv_json() {
+        Some(path) => path,
+        None => {
+            println!("Skipping search_finds_multiple_books: en_kjv.json not found");
+            return;
+        }
+    };
+
+    let bible = Bible::new_from_json(&file_path).expect("Failed to load Bible JSON");
+    let results = bible.search("in the beginning");
+    assert!(results.contains(&(BibleBook::Genesis, 1, 1)));
+    assert!(results.contains(&(BibleBook::John, 1, 1)));
+}
+
+#[test]
+fn search_is_case_insensitive() {
+    let file_path = match test_utils::get_kjv_json() {
+        Some(path) => path,
+        None => {
+            println!("Skipping search_is_case_insensitive: en_kjv.json not found");
+            return;
+        }
+    };
+
+    let bible = Bible::new_from_json(&file_path).expect("Failed to load Bible JSON");
+    let results = bible.search("REJOICE EVERMORE");
+    assert_eq!(results, vec![(BibleBook::FirstThessalonians, 5, 16)]);
+}


### PR DESCRIPTION
## Summary
- add `search` API to scan all verses for a case-insensitive substring
- document linear-scan performance caveats
- test verse search across books and case-insensitivity

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_b_68a3927114d0832b8506a0f8c4f26da1