### PR TITLE
Handle ordered chapter and verse maps

### DIFF
--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -59,6 +59,19 @@ fn test_bible_creation_with_real_data() {
     if let Ok(book) = bible.get_book(BibleBook::Genesis) {
         assert_eq!(book.abbrev(), "gn");
         assert_eq!(book.title(), "Genesis");
+
+        let chapters = book.chapters();
+        assert!(!chapters.is_empty());
+        assert_eq!(chapters[0].number(), 1);
+        if chapters.len() > 1 {
+            assert_eq!(chapters[1].number(), 2);
+        }
+
+        let verses = chapters[0].get_verses();
+        assert!(verses.len() >= 3);
+        assert_eq!(verses[0].number(), 1);
+        assert_eq!(verses[1].number(), 2);
+        assert_eq!(verses[2].number(), 3);
     }
 }
 

--- a/tests/reference_tests.rs
+++ b/tests/reference_tests.rs
@@ -45,9 +45,8 @@ fn test_get_verse_by_reference_valid() {
     let verse = bible
         .get_verse_by_reference("Rev 22:21")
         .expect("Verse not found");
-    assert!(verse
-        .text()
-        .starts_with("The grace of our Lord Jesus Christ be with you all"));
+    let normalized = verse.text().replace('{', "").replace('}', "");
+    assert!(normalized.starts_with("The grace of our Lord Jesus Christ be with you all"));
 }
 
 #[test]

--- a/tests/verse_text_tests.rs
+++ b/tests/verse_text_tests.rs
@@ -91,11 +91,19 @@ fn test_first_and_last_verses_of_each_book() {
         let verse = bible
             .get_verse(*book, *f_ch, *f_vs)
             .unwrap_or_else(|_| panic!("Missing first verse for {:?}", book));
-        assert_eq!(format!("{}: {}", f_vs, f_text), format!("{}", verse));
+        let expected_first = format!("{}: {}", f_vs, f_text)
+            .replace('{', "")
+            .replace('}', "");
+        let actual_first = format!("{}", verse).replace('{', "").replace('}', "");
+        assert_eq!(expected_first, actual_first);
 
         let verse = bible
             .get_verse(*book, *l_ch, *l_vs)
             .unwrap_or_else(|_| panic!("Missing last verse for {:?}", book));
-        assert_eq!(format!("{}: {}", l_vs, l_text), format!("{}", verse));
+        let expected_last = format!("{}: {}", l_vs, l_text)
+            .replace('{', "")
+            .replace('}', "");
+        let actual_last = format!("{}", verse).replace('{', "").replace('}', "");
+        assert_eq!(expected_last, actual_last);
     }
 }


### PR DESCRIPTION
## Summary
- update the JSON loader to read chapter and verse maps from IndexMap and build Bible content in numeric order
- add coverage ensuring numeric ordering is preserved when constructing Bibles from maps and real fixtures
- normalize reference tests to account for brace annotations in the updated KJV fixture

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_b_68ce9a3550f4832ba51c35167faebadc