### PR TITLE
Handle map-based Bible JSON structure and sanitize verse text

### DIFF
--- a/src/verse.rs
+++ b/src/verse.rs
@@ -18,7 +18,7 @@ impl Verse {
     /// * `verse_number` - The verse number within its chapter
     pub fn new(verse_text: String, verse_number: usize) -> Self {
         Verse {
-            verse_text,
+            verse_text: sanitize_verse_text(verse_text),
             verse_number,
         }
     }
@@ -32,6 +32,13 @@ impl Verse {
     pub fn number(&self) -> usize {
         self.verse_number
     }
+}
+
+fn sanitize_verse_text(verse_text: String) -> String {
+    verse_text
+        .chars()
+        .filter(|c| *c != '{' && *c != '}')
+        .collect()
 }
 
 impl fmt::Display for Verse {
@@ -50,6 +57,12 @@ mod tests {
         assert_eq!(verse.text(), "Test");
         assert_eq!(verse.number(), 1);
         assert_eq!(format!("{}", verse), "1: Test");
+    }
+
+    #[test]
+    fn test_sanitize_verse_text() {
+        let verse = Verse::new("In {the} beginning".to_string(), 1);
+        assert_eq!(verse.text(), "In the beginning");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- allow `Bible::new_from_json` to consume JSON files that use chapter and verse maps by normalizing them into arrays
- strip curly-brace markup from verse text on construction and add a unit test for the sanitizer

## Testing
- cargo test --all-targets --all-features

------
https://chatgpt.com/codex/tasks/task_b_68ce9e3fc1e4832b8f2c2819016d2921