### PR TITLE
Include book and chapter info in verses

### DIFF
--- a/src/book.rs
+++ b/src/book.rs
@@ -121,10 +121,10 @@ impl fmt::Display for Book {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::verse::Verse;
+    use crate::{bible_books_enum::BibleBook, verse::Verse};
 
     fn create_test_chapter() -> Chapter {
-        let verses = vec![Verse::new("Test".into(), 1)];
+        let verses = vec![Verse::new(BibleBook::Genesis, 1, 1, "Test".into())];
         Chapter::new(verses, 1)
     }
 

--- a/src/chapter.rs
+++ b/src/chapter.rs
@@ -71,10 +71,11 @@ impl fmt::Display for Chapter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::bible_books_enum::BibleBook;
 
     #[test]
     fn test_new_and_accessors() {
-        let verses = vec![Verse::new("Test".into(), 1)];
+        let verses = vec![Verse::new(BibleBook::Genesis, 1, 1, "Test".into())];
         let chapter = Chapter::new(verses, 1);
         assert_eq!(chapter.number(), 1);
         assert_eq!(chapter.get_verses().len(), 1);
@@ -84,7 +85,7 @@ mod tests {
 
     #[test]
     fn test_clone_independence() {
-        let verses = vec![Verse::new("Clone".into(), 1)];
+        let verses = vec![Verse::new(BibleBook::Genesis, 1, 1, "Clone".into())];
         let original = Chapter::new(verses, 1);
         let cloned = original.clone();
 

--- a/src/verse.rs
+++ b/src/verse.rs
@@ -1,10 +1,14 @@
 use std::fmt;
 
+use crate::bible_books_enum::BibleBook;
+
 /// Represents a single verse from the Bible.
 ///
-/// A verse contains the text content and its verse number within a chapter.
-#[derive(Debug, Clone)]
+/// A verse contains the text content and its reference information within a chapter.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Verse {
+    book: BibleBook,
+    chapter_number: usize,
     verse_text: String,
     verse_number: usize,
 }
@@ -14,13 +18,32 @@ impl Verse {
     ///
     /// # Arguments
     ///
-    /// * `verse_text` - The text content of the verse
+    /// * `book` - The book this verse belongs to
+    /// * `chapter_number` - The chapter number within the book
     /// * `verse_number` - The verse number within its chapter
-    pub fn new(verse_text: String, verse_number: usize) -> Self {
+    /// * `verse_text` - The text content of the verse
+    pub fn new(
+        book: BibleBook,
+        chapter_number: usize,
+        verse_number: usize,
+        verse_text: String,
+    ) -> Self {
         Verse {
+            book,
+            chapter_number,
             verse_text: sanitize_verse_text(verse_text),
             verse_number,
         }
+    }
+
+    /// Returns the book this verse belongs to.
+    pub fn book(&self) -> BibleBook {
+        self.book
+    }
+
+    /// Returns the chapter number within the book.
+    pub fn chapter(&self) -> usize {
+        self.chapter_number
     }
 
     /// Returns the text content of the verse.
@@ -53,7 +76,9 @@ mod tests {
 
     #[test]
     fn test_new_and_accessors() {
-        let verse = Verse::new("Test".to_string(), 1);
+        let verse = Verse::new(BibleBook::Genesis, 1, 1, "Test".to_string());
+        assert_eq!(verse.book(), BibleBook::Genesis);
+        assert_eq!(verse.chapter(), 1);
         assert_eq!(verse.text(), "Test");
         assert_eq!(verse.number(), 1);
         assert_eq!(format!("{}", verse), "1: Test");
@@ -61,15 +86,17 @@ mod tests {
 
     #[test]
     fn test_sanitize_verse_text() {
-        let verse = Verse::new("In {the} beginning".to_string(), 1);
+        let verse = Verse::new(BibleBook::Genesis, 1, 1, "In {the} beginning".to_string());
         assert_eq!(verse.text(), "In the beginning");
     }
 
     #[test]
     fn test_clone_independence() {
-        let original = Verse::new("Clone me".to_string(), 42);
+        let original = Verse::new(BibleBook::Genesis, 1, 42, "Clone me".to_string());
         let cloned = original.clone();
 
+        assert_eq!(original.book(), cloned.book());
+        assert_eq!(original.chapter(), cloned.chapter());
         assert_eq!(original.text(), cloned.text());
         assert_eq!(original.number(), cloned.number());
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -10,7 +10,7 @@ fn test_library_imports() {
     use bible_io::Verse;
 
     // Create a simple verse to test the import
-    let verse = Verse::new("Test verse".to_string(), 1);
+    let verse = Verse::new(BibleBook::Genesis, 1, 1, "Test verse".to_string());
     // Note: We can't access private fields in integration tests
     // This test just verifies the import works
     assert_eq!(format!("{}", verse), "1: Test verse");

--- a/tests/search_tests.rs
+++ b/tests/search_tests.rs
@@ -17,11 +17,29 @@ fn search_finds_multiple_books() {
     let index = bible.build_search_index();
     let query = "in the beginning";
     let search_results = bible.search(query);
-    assert!(search_results.contains(&(BibleBook::Genesis, 1, 1)));
-    assert!(search_results.contains(&(BibleBook::John, 1, 1)));
+    let genesis = bible
+        .get_verse(BibleBook::Genesis, 1, 1)
+        .expect("Missing Genesis 1:1")
+        .clone();
+    let john = bible
+        .get_verse(BibleBook::John, 1, 1)
+        .expect("Missing John 1:1")
+        .clone();
+
+    assert!(search_results.contains(&genesis));
+    assert!(search_results.contains(&john));
 
     let indexed_results = index.search(query);
-    assert_eq!(search_results, indexed_results);
+    let verses_from_index: Vec<_> = indexed_results
+        .into_iter()
+        .map(|(book, chapter, verse)| {
+            bible
+                .get_verse(book, chapter, verse)
+                .expect("Indexed verse missing from Bible")
+                .clone()
+        })
+        .collect();
+    assert_eq!(search_results, verses_from_index);
 }
 
 #[test]
@@ -39,6 +57,21 @@ fn search_is_case_insensitive() {
     let query = "REJOICE EVERMORE";
     let search_results = bible.search(query);
     let indexed_results = index.search(query);
-    assert_eq!(search_results, vec![(BibleBook::FirstThessalonians, 5, 16)]);
-    assert_eq!(search_results, indexed_results);
+
+    let expected = bible
+        .get_verse(BibleBook::FirstThessalonians, 5, 16)
+        .expect("Missing 1 Thessalonians 5:16")
+        .clone();
+
+    assert_eq!(search_results, vec![expected.clone()]);
+    let verses_from_index: Vec<_> = indexed_results
+        .into_iter()
+        .map(|(book, chapter, verse)| {
+            bible
+                .get_verse(book, chapter, verse)
+                .expect("Indexed verse missing from Bible")
+                .clone()
+        })
+        .collect();
+    assert_eq!(search_results, verses_from_index);
 }


### PR DESCRIPTION
## Summary
- extend the `Verse` struct with book and chapter metadata plus accessors
- populate the added metadata when building the Bible and return full verses from search results
- adjust unit/integration/search tests for the new constructor and search behaviour

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_b_68cef44a8174832baf1f164bd75b40df